### PR TITLE
E2E for dataset details

### DIFF
--- a/tests/app/dataset-details.spec.ts
+++ b/tests/app/dataset-details.spec.ts
@@ -3,6 +3,24 @@ import { expect, test } from '@playwright/test';
 import { DatasetDetailsPage } from "./details-dataset.page";
 import { NewDatasetPage } from "./new-dataset.page";
 
+test('page content layout', async ({ page }) => {
+    // given
+    const datasetDetailsPage = new DatasetDetailsPage(page)
+    const newDatasetPage = new NewDatasetPage(page);
+    const expectedDatasetTitle = faker.commerce.productName()
+
+    // when
+    await newDatasetPage.goto()
+    await newDatasetPage.createNewDataset(expectedDatasetTitle)
+
+    // then
+    await expect(datasetDetailsPage.datasetTitle).toHaveText(expectedDatasetTitle)
+    await expect(datasetDetailsPage.buttonListDatasetVersion1).toBeVisible()
+    await expect(datasetDetailsPage.buttonEditInstitution).toBeVisible()
+    await expect(datasetDetailsPage.buttonGenerateDOIAutomatically).toBeVisible()
+    await expect(datasetDetailsPage.buttonGenerateDOIManually).toBeVisible()    
+});
+
 test('new version dataset buttons available', async ({ page }) => {
     // given
     const datasetDetailsPage = new DatasetDetailsPage(page)
@@ -28,7 +46,7 @@ test('register DOI automatically', async ({ page }) => {
     await newDatasetPage.goto()
     await newDatasetPage.createNewDataset(expectedDatasetTitle)
     await datasetDetailsPage.editInstituionName(faker.company.name())
-    await newDatasetPage.registerDOIAutomatically()
+    await datasetDetailsPage.registerDOIAutomatically()
 
     // then
     await expect(datasetDetailsPage.buttonListDatasetVersion1).toBeVisible()
@@ -51,7 +69,7 @@ test('register DOI manually', async ({ page }) => {
     await newDatasetPage.goto()
     await newDatasetPage.createNewDataset(expectedDatasetTitle)
     await datasetDetailsPage.editInstituionName(faker.company.name())
-    await newDatasetPage.registerDOIManually()
+    await datasetDetailsPage.registerDOIManually()
 
     // then
     await expect(datasetDetailsPage.buttonListDatasetVersion1).toBeVisible()

--- a/tests/app/details-dataset.page.ts
+++ b/tests/app/details-dataset.page.ts
@@ -1,3 +1,4 @@
+import { faker } from "@faker-js/faker";
 import { expect, type Locator, type Page } from '@playwright/test';
 
 export class DatasetDetailsPage {
@@ -14,6 +15,13 @@ export class DatasetDetailsPage {
   readonly cardItemDoiStatus: Locator;
   readonly cardItemDoiStatusNavigator: Locator;
   readonly buttonDoiStatusNavigator: Locator;
+  readonly buttonGenerateDOIAutomatically: Locator;
+  readonly buttonGenerateDOIAutomaticallyRegisterConfirmation: Locator;
+
+  readonly buttonGenerateDOIManually: Locator;
+  readonly buttonGenerateDOIManuallySave: Locator;
+  readonly inputGenerateDOIManuallyIdentifier: Locator;
+
 
   constructor(page: Page) {
     this.page = page;
@@ -30,6 +38,12 @@ export class DatasetDetailsPage {
     this.cardItemDoiStatus = page.getByTestId("doi-register-status")
     this.cardItemDoiStatusNavigator = page.getByTestId("doi-status-navigator")
     this.buttonDoiStatusNavigator = this.cardItemDoiStatusNavigator.getByRole('button')
+
+    this.buttonGenerateDOIAutomatically = page.getByRole('button', { name: "Generate DOI Automatically" })
+    this.buttonGenerateDOIAutomaticallyRegisterConfirmation = page.getByRole('button', { name: "Register" })
+    this.buttonGenerateDOIManually = page.getByRole('button', { name: 'Register Manual DOI' })
+    this.inputGenerateDOIManuallyIdentifier = page.getByPlaceholder('10.1000/182')
+    this.buttonGenerateDOIManuallySave = page.getByRole('button', { name: 'Save' })
   }
 
   async goto(datasetId: string) {
@@ -45,5 +59,16 @@ export class DatasetDetailsPage {
     await this.buttonEditInstitution.click()
     await this.inputInstituitonName.fill(expectedInstitutionName)
     await this.buttonSaveInstitution.click()
+  }
+
+  async registerDOIAutomatically() {
+    await this.buttonGenerateDOIAutomatically.click()
+    await this.buttonGenerateDOIAutomaticallyRegisterConfirmation.click()
+  }
+
+  async registerDOIManually() {
+    await this.buttonGenerateDOIManually.click()
+    await this.inputGenerateDOIManuallyIdentifier.fill(`10.1000/${faker.airline.flightNumber({ length: { min: 6, max: 10 } })}`)
+    await this.buttonGenerateDOIManuallySave.click()
   }
 }

--- a/tests/app/new-dataset.page.ts
+++ b/tests/app/new-dataset.page.ts
@@ -1,4 +1,3 @@
-import { faker } from "@faker-js/faker";
 import { expect, type Locator, type Page } from '@playwright/test';
 import path from "path";
 
@@ -12,13 +11,7 @@ export class NewDatasetPage {
   readonly buttonBrowseFolderUpload: Locator;
   readonly buttonCreateDataset: Locator;
   readonly buttonViewDataset: Locator;
-  readonly buttonGenerateDOIAutomatically: Locator;
-  readonly buttonGenerateDOIAutomaticallyRegisterConfirmation: Locator;
-
-  readonly buttonGenerateDOIManually: Locator;
-  readonly buttonGenerateDOIManuallySave: Locator;
-  readonly inputGenerateDOIManuallyIdentifier: Locator;
-
+  
   constructor(page: Page) {
     this.page = page;
 
@@ -30,11 +23,6 @@ export class NewDatasetPage {
     this.buttonBrowseFolderUpload = page.getByRole('button', { name: 'browse folders' })
     this.buttonCreateDataset = page.getByRole('button', { name: 'Create Dataset' })
     this.buttonViewDataset = page.getByRole('button', { name: "View Dataset" })
-    this.buttonGenerateDOIAutomatically = page.getByRole('button', { name: "Generate DOI Automatically" })
-    this.buttonGenerateDOIAutomaticallyRegisterConfirmation = page.getByRole('button', { name: "Register" })
-    this.buttonGenerateDOIManually = page.getByRole('button', { name: 'Register Manual DOI' })
-    this.inputGenerateDOIManuallyIdentifier = page.getByPlaceholder('10.1000/182')
-    this.buttonGenerateDOIManuallySave = page.getByRole('button', { name: 'Save' })
   }
 
   async goto() {
@@ -58,16 +46,5 @@ export class NewDatasetPage {
     await expect(this.buttonCreateDataset).toBeEnabled({ timeout: 15000 })
     await this.buttonCreateDataset.click()
     await this.buttonViewDataset.click()
-  }
-
-  async registerDOIAutomatically() {
-    await this.buttonGenerateDOIAutomatically.click()
-    await this.buttonGenerateDOIAutomaticallyRegisterConfirmation.click()
-  }
-
-  async registerDOIManually() {
-    await this.buttonGenerateDOIManually.click()
-    await this.inputGenerateDOIManuallyIdentifier.fill(`10.1000/${faker.airline.flightNumber({ length: { min: 6, max: 10 } })}`)
-    await this.buttonGenerateDOIManuallySave.click()
   }
 }


### PR DESCRIPTION
## 🤔 Problem
No coverage for dataset details page

## 🧐 Solution
Start covering some basic cases

## 🤨 Rationale
Just checking if some basic element are visible in the page

## 🧪 E2E test results
Run `npm run test` and print the results here

```
➜  datamap-e2e git:(test-doi-register) ✗ npx playwright test

Running 22 tests using 4 workers
[web-auth-setup] › auth.setup.ts:5:6 › authenticate
Test user authenticated: {
  id: '3c097282-4f30-46b6-8ba7-efb3dda191ec',
  name: 'Rafael Wisozk',
  email: 'Margarett90@local.datamap.com',
  roles: [],
  is_enabled: true,
  created_at: '2024-10-31T16:48:10.394576Z',
  updated_at: '2024-10-31T16:48:10.394576Z',
  providers: [
    { name: 'credentials', reference: 'Margarett90@local.datamap.com' }
  ],
  tenancies: []
}
Cookies generated and stored at: /Users/andre.maia/workspace/datamap-e2e/playwright-report/.auth/user.json
  22 passed (37.3s)

To open last HTML report run:

  npx playwright show-report
```