### PR TITLE
Download individual file e2e

### DIFF
--- a/tests/app/dataset-details.spec.ts
+++ b/tests/app/dataset-details.spec.ts
@@ -1,5 +1,6 @@
 import { faker } from "@faker-js/faker";
 import { expect, test } from '@playwright/test';
+import fs from 'fs';
 import { DatasetDetailsPage } from "./details-dataset.page";
 import { NewDatasetPage } from "./new-dataset.page";
 
@@ -18,7 +19,7 @@ test('page content layout', async ({ page }) => {
     await expect(datasetDetailsPage.buttonListDatasetVersion1).toBeVisible()
     await expect(datasetDetailsPage.buttonEditInstitution).toBeVisible()
     await expect(datasetDetailsPage.buttonGenerateDOIAutomatically).toBeVisible()
-    await expect(datasetDetailsPage.buttonGenerateDOIManually).toBeVisible()    
+    await expect(datasetDetailsPage.buttonGenerateDOIManually).toBeVisible()
 });
 
 test('new version dataset buttons available', async ({ page }) => {
@@ -78,4 +79,22 @@ test('register DOI manually', async ({ page }) => {
     await expect(datasetDetailsPage.cardItemDoiMode).toContainText("MANUAL")
     await expect(datasetDetailsPage.cardItemDoiStatus).toBeHidden()
     await expect(datasetDetailsPage.buttonDoiStatusNavigator).toBeHidden()
+});
+
+
+test('download individual file', async ({ page }) => {
+    // given
+    const datasetDetailsPage = new DatasetDetailsPage(page)
+    const newDatasetPage = new NewDatasetPage(page);
+    const expectedDatasetTitle = faker.commerce.productName()
+
+    // when
+    await newDatasetPage.goto()
+    await newDatasetPage.createNewDataset(expectedDatasetTitle)
+    const fileSaved = await datasetDetailsPage.downloadFirstFileAvailable()
+
+    // then
+    await expect(datasetDetailsPage.dataFileItem).toBeVisible()
+    await expect(datasetDetailsPage.buttonDataFileItemDownload).toBeVisible()
+    expect(fs.existsSync(fileSaved)).toBeTruthy()
 });


### PR DESCRIPTION
## 🤔 Problem
Download files are not covered.

## 🧐 Solution
Coverage download individual file e2e

## 🧪 E2E test results
Run `npm run test` and print the results here

```
➜  datamap-e2e git:(test-dataset-download) ✗ npx playwright test

Running 23 tests using 4 workers
[web-auth-setup] › auth.setup.ts:5:6 › authenticate
Test user authenticated: {
  id: '17fd47e3-4efc-48f6-8c75-0c5e6801255e',
  name: 'Alexander Morar',
  email: 'Deontae_Runte@local.datamap.com',
  roles: [],
  is_enabled: true,
  created_at: '2024-11-03T01:43:59.239756Z',
  updated_at: '2024-11-03T01:43:59.239756Z',
  providers: [
    {
      name: 'credentials',
      reference: 'Deontae_Runte@local.datamap.com'
    }
  ],
  tenancies: []
}
Cookies generated and stored at: /Users/andre.maia/workspace/datamap-e2e/playwright-report/.auth/user.json
  23 passed (42.1s)

To open last HTML report run:

  npx playwright show-report
```